### PR TITLE
Merge feature/telegram-bot-sender into develop

### DIFF
--- a/notification-service/pom.xml
+++ b/notification-service/pom.xml
@@ -56,6 +56,32 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.7.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>0.11.5</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>0.11.5</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>0.11.5</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/notification-service/src/main/java/com/jobflow/notification_service/exception/InvalidTelegramTokenException.java
+++ b/notification-service/src/main/java/com/jobflow/notification_service/exception/InvalidTelegramTokenException.java
@@ -1,0 +1,7 @@
+package com.jobflow.notification_service.exception;
+
+public class InvalidTelegramTokenException extends RuntimeException {
+    public InvalidTelegramTokenException(String message) {
+        super(message);
+    }
+}

--- a/notification-service/src/main/java/com/jobflow/notification_service/exception/UserClientException.java
+++ b/notification-service/src/main/java/com/jobflow/notification_service/exception/UserClientException.java
@@ -1,6 +1,10 @@
 package com.jobflow.notification_service.exception;
 
 public class UserClientException extends RuntimeException {
+    public UserClientException(String message) {
+        super(message);
+    }
+
     public UserClientException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/notification-service/src/main/java/com/jobflow/notification_service/handler/GlobalHandler.java
+++ b/notification-service/src/main/java/com/jobflow/notification_service/handler/GlobalHandler.java
@@ -1,0 +1,24 @@
+package com.jobflow.notification_service.handler;
+
+import com.jobflow.notification_service.exception.InvalidTelegramTokenException;
+import com.jobflow.notification_service.exception.UserClientException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GlobalHandler.class);
+
+    @ExceptionHandler(InvalidTelegramTokenException.class)
+    public ResponseEntity<ResponseError> invalidTelegramTokenExcHandler(InvalidTelegramTokenException exc) {
+        LOGGER.error("[Invalid Token Exception]: {}", exc.getMessage());
+        ResponseError responseError = ResponseError.buildResponseError(exc.getMessage(), HttpStatus.UNAUTHORIZED.value());
+
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(responseError);
+    }
+}

--- a/notification-service/src/main/java/com/jobflow/notification_service/handler/ResponseError.java
+++ b/notification-service/src/main/java/com/jobflow/notification_service/handler/ResponseError.java
@@ -1,0 +1,30 @@
+package com.jobflow.notification_service.handler;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Response error details")
+public class ResponseError {
+
+    @Schema(description = "Error message", example = "Error message")
+    private String message;
+
+    @Schema(description = "Error status", example = "000")
+    private int status;
+
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
+    @Schema(description = "Error occurrence time", example = "2021-01-01 01:01")
+    private LocalDateTime time;
+
+    public static ResponseError buildResponseError(String message, int status) {
+        return new ResponseError(message, status, LocalDateTime.now());
+    }
+}

--- a/notification-service/src/main/java/com/jobflow/notification_service/jwt/JwtService.java
+++ b/notification-service/src/main/java/com/jobflow/notification_service/jwt/JwtService.java
@@ -1,0 +1,14 @@
+package com.jobflow.notification_service.jwt;
+
+import io.jsonwebtoken.Claims;
+
+import java.security.Key;
+
+public interface JwtService {
+
+    Claims extractClaims(String token);
+
+    String extractUserId(String token);
+
+    Key getSecretKey();
+}

--- a/notification-service/src/main/java/com/jobflow/notification_service/jwt/JwtServiceImpl.java
+++ b/notification-service/src/main/java/com/jobflow/notification_service/jwt/JwtServiceImpl.java
@@ -1,0 +1,48 @@
+package com.jobflow.notification_service.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.security.Key;
+
+@Service
+public class JwtServiceImpl implements JwtService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(JwtServiceImpl.class);
+
+    private final String SECRET_KEY;
+
+    public JwtServiceImpl(@Value("${jwt.secret-key}") String SECRET_KEY) {
+        this.SECRET_KEY = SECRET_KEY;
+    }
+
+    @Override
+    public Claims extractClaims(String token) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(getSecretKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+
+        LOGGER.debug("Extracted claims from token for userId: {}", claims.getSubject());
+        return claims;
+    }
+
+    @Override
+    public String extractUserId(String token) {
+        return extractClaims(token).getSubject();
+    }
+
+    @Override
+    public Key getSecretKey() {
+        byte[] decodeKey = Decoders.BASE64.decode(SECRET_KEY);
+
+        return Keys.hmacShaKeyFor(decodeKey);
+    }
+}

--- a/notification-service/src/main/java/com/jobflow/notification_service/openApi/OpenApiConfig.java
+++ b/notification-service/src/main/java/com/jobflow/notification_service/openApi/OpenApiConfig.java
@@ -1,4 +1,4 @@
-package com.jobflow.job_tracker_service.openApi;
+package com.jobflow.notification_service.openApi;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Contact;
@@ -8,11 +8,11 @@ import org.springframework.context.annotation.Configuration;
 
 @OpenAPIDefinition(
         servers = @Server(
-                url = "http://localhost:8081"
+                url = "http://localhost:8082"
         ),
         info = @Info(
-                title = "Job Tracker service",
-                description = "Job Tracker service API documentation",
+                title = "Notification service",
+                description = "Notification service API documentation",
                 version = "1.0.0",
                 contact = @Contact(
                         name = "Mikhail Malygin",

--- a/notification-service/src/main/java/com/jobflow/notification_service/telegram/TelegramChat.java
+++ b/notification-service/src/main/java/com/jobflow/notification_service/telegram/TelegramChat.java
@@ -1,0 +1,17 @@
+package com.jobflow.notification_service.telegram;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TelegramChat {
+
+    private Long id;
+
+    private String type;
+}

--- a/notification-service/src/main/java/com/jobflow/notification_service/telegram/TelegramChatLinkRequest.java
+++ b/notification-service/src/main/java/com/jobflow/notification_service/telegram/TelegramChatLinkRequest.java
@@ -1,0 +1,17 @@
+package com.jobflow.notification_service.telegram;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TelegramChatLinkRequest {
+
+    private Long userId;
+
+    private Long chatId;
+}

--- a/notification-service/src/main/java/com/jobflow/notification_service/telegram/TelegramController.java
+++ b/notification-service/src/main/java/com/jobflow/notification_service/telegram/TelegramController.java
@@ -1,0 +1,28 @@
+package com.jobflow.notification_service.telegram;
+
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/telegram")
+@RequiredArgsConstructor
+public class TelegramController {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TelegramController.class);
+
+    private final TelegramService telegramService;
+
+    @PostMapping("/webhook")
+    public ResponseEntity<Void> receiveUpdate(
+            @RequestHeader("X-Telegram-Bot-Api-Secret-Token") String token,
+            @RequestBody TelegramUpdate telegramUpdate
+    ) {
+        LOGGER.info("[POST] Telegram webhook request received");
+        telegramService.processUpdate(telegramUpdate, token);
+
+        return ResponseEntity.ok().build();
+    }
+}

--- a/notification-service/src/main/java/com/jobflow/notification_service/telegram/TelegramMessage.java
+++ b/notification-service/src/main/java/com/jobflow/notification_service/telegram/TelegramMessage.java
@@ -1,0 +1,19 @@
+package com.jobflow.notification_service.telegram;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TelegramMessage {
+
+    private String text;
+
+    private TelegramChat chat;
+
+    private TelegramUser from;
+}

--- a/notification-service/src/main/java/com/jobflow/notification_service/telegram/TelegramService.java
+++ b/notification-service/src/main/java/com/jobflow/notification_service/telegram/TelegramService.java
@@ -1,0 +1,6 @@
+package com.jobflow.notification_service.telegram;
+
+public interface TelegramService {
+
+    void processUpdate(TelegramUpdate telegramUpdate, String token);
+}

--- a/notification-service/src/main/java/com/jobflow/notification_service/telegram/TelegramServiceImpl.java
+++ b/notification-service/src/main/java/com/jobflow/notification_service/telegram/TelegramServiceImpl.java
@@ -1,0 +1,60 @@
+package com.jobflow.notification_service.telegram;
+
+import com.jobflow.notification_service.exception.InvalidTelegramTokenException;
+import com.jobflow.notification_service.jwt.JwtService;
+import com.jobflow.notification_service.user.UserClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class TelegramServiceImpl implements TelegramService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TelegramServiceImpl.class);
+
+    private final JwtService jwtService;
+    private final UserClient userClient;
+    private final String token;
+
+    public TelegramServiceImpl(JwtService jwtService,
+                               UserClient userClient,
+                               @Value("${telegram.bot.secret-token}") String token) {
+        this.jwtService = jwtService;
+        this.userClient = userClient;
+        this.token = token;
+    }
+
+    @Override
+    public void processUpdate(TelegramUpdate telegramUpdate, String token) {
+        LOGGER.debug("Processing telegram webhook request");
+
+        if (!this.token.equals(token)) {
+            throw new InvalidTelegramTokenException("Token: " + token + " invalid");
+        }
+
+        try {
+            TelegramMessage message = telegramUpdate.getMessage();
+            if (message == null || message.getText() == null) {
+                LOGGER.debug("The message was not found. Skip telegram webhook request");
+                return;
+            }
+
+            String text = message.getText();
+            if (text.startsWith("/start ")) {
+                String jwtToken = text.substring("/start ".length());
+                Long userId = Long.valueOf(jwtService.extractUserId(jwtToken));
+
+                Long chatId = message.getChat().getId();
+                userClient.linkChatId(userId, chatId);
+
+                LOGGER.debug("Successfully processed telegram webhook request. chatId: {}, userId: {}", chatId, userId);
+            } else {
+                LOGGER.debug("The text does not starts with '/start '. Skip telegram webhook request");
+            }
+        } catch (Exception e) {
+            //Not throwing exc because the telegram bot api resends the requests 24 hours until it receives 2xx
+            LOGGER.error("Failed to process telegram webhook request: {}", e.getMessage(), e);
+        }
+    }
+}

--- a/notification-service/src/main/java/com/jobflow/notification_service/telegram/TelegramUpdate.java
+++ b/notification-service/src/main/java/com/jobflow/notification_service/telegram/TelegramUpdate.java
@@ -1,0 +1,20 @@
+package com.jobflow.notification_service.telegram;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * A message sent by the bot when the user sends a
+ * message. It is used to associate a chat with a user
+ * and send notifications.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TelegramUpdate {
+
+    private TelegramMessage message;
+}

--- a/notification-service/src/main/java/com/jobflow/notification_service/telegram/TelegramUser.java
+++ b/notification-service/src/main/java/com/jobflow/notification_service/telegram/TelegramUser.java
@@ -1,0 +1,19 @@
+package com.jobflow.notification_service.telegram;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TelegramUser {
+
+    private Long id;
+
+    private Boolean is_bot;
+
+    private String first_name;
+}

--- a/notification-service/src/main/java/com/jobflow/notification_service/user/UserClient.java
+++ b/notification-service/src/main/java/com/jobflow/notification_service/user/UserClient.java
@@ -3,4 +3,6 @@ package com.jobflow.notification_service.user;
 public interface UserClient {
 
     UserInfo getUserInfo(Long userId);
+
+    void linkChatId(Long userId, Long chatId);
 }

--- a/notification-service/src/main/java/com/jobflow/notification_service/user/UserInfo.java
+++ b/notification-service/src/main/java/com/jobflow/notification_service/user/UserInfo.java
@@ -1,5 +1,6 @@
 package com.jobflow.notification_service.user;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -9,9 +10,12 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "A dto representing information about the user. It is used for micro-service interaction")
 public class UserInfo {
 
+    @Schema(description = "User email", example = "IvanIvanov@gmail.com")
     private String email;
 
-    private String telegramChatId;
+    @Schema(description = "Telegram chat ID", example = "123")
+    private Long telegramChatId;
 }

--- a/notification-service/src/main/resources/application.properties
+++ b/notification-service/src/main/resources/application.properties
@@ -2,10 +2,10 @@ spring.application.name=notification-service
 
 management.endpoints.web.exposure.include=health
 
-spring.mail.host=smtp.gmail.com
-spring.mail.port=587
 spring.mail.username=${EMAIL_USERNAME}
 spring.mail.password=${EMAIL_PASSWORD}
+spring.mail.host=smtp.gmail.com
+spring.mail.port=587
 spring.mail.protocol=smtp
 
 spring.rabbitmq.host=${RABBITMQ_HOST}
@@ -18,8 +18,13 @@ spring.rabbitmq.exchange-name=notification.exchange
 spring.rabbitmq.email-queue-routing-key=notification.email.queue
 spring.rabbitmq.telegram-queue-routing-key=notification.telegram.queue
 
+jwt.secret-key=${JWT_SECRET_KEY}
+
 user.service.host=${USER_SERVICE_HOST}
 user.service.port=${USER_SERVICE_HOST}
 user.service.api-key=${USER_SERVICE_API_KEY}
+
+telegram.bot.token=${TELEGRAM_BOT_TOKEN}
+telegram.bot.secret-token=${TELEGRAM_BOT_SECRET_TOKEN}
 
 

--- a/notification-service/src/test/java/com/jobflow/notification_service/JwtTestUtil.java
+++ b/notification-service/src/test/java/com/jobflow/notification_service/JwtTestUtil.java
@@ -1,0 +1,34 @@
+package com.jobflow.notification_service;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.test.annotation.Commit;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+
+/**
+ * A utility class for generating a JWT token using
+ * a secret from test/application.properties
+ */
+@Component
+public class JwtTestUtil {
+    @Value("${jwt.secret-key}")
+    private String secretKey;
+
+    public String generateToken(Long userId) {
+        byte[] decodeKey = Decoders.BASE64.decode(secretKey);
+        SecretKey key = Keys.hmacShaKeyFor(decodeKey);
+
+        return Jwts.builder()
+                .setSubject(userId.toString())
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + 1000 * 60))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+}

--- a/notification-service/src/test/java/com/jobflow/notification_service/TestUtil.java
+++ b/notification-service/src/test/java/com/jobflow/notification_service/TestUtil.java
@@ -2,7 +2,13 @@ package com.jobflow.notification_service;
 
 import com.jobflow.notification_service.notification.NotificationEvent;
 import com.jobflow.notification_service.notification.NotificationType;
+import com.jobflow.notification_service.telegram.TelegramChat;
+import com.jobflow.notification_service.telegram.TelegramMessage;
+import com.jobflow.notification_service.telegram.TelegramUpdate;
+import com.jobflow.notification_service.telegram.TelegramUser;
 import com.jobflow.notification_service.user.UserInfo;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
 
 /**
  * A utility class for use in unit/integration tests
@@ -14,6 +20,10 @@ public final class TestUtil {
 
     private TestUtil() {
 
+    }
+
+    public static <T> HttpEntity<T> createRequest(T request, HttpHeaders headers) {
+        return new HttpEntity<>(request, headers);
     }
 
     public static NotificationEvent createNotificationEvent() {
@@ -28,7 +38,28 @@ public final class TestUtil {
     public static UserInfo createUserInfo() {
         return UserInfo.builder()
                 .email("IvanIvanov@gmail.com")
-                .telegramChatId("123")
+                .telegramChatId(1L)
+                .build();
+    }
+
+    public static TelegramUpdate createTelegramUpdate() {
+        TelegramChat chat = TelegramChat.builder()
+                .id(1L)
+                .type("private")
+                .build();
+        TelegramUser user = TelegramUser.builder()
+                .id(1L)
+                .is_bot(Boolean.FALSE)
+                .first_name("Ivan")
+                .build();
+        TelegramMessage message = TelegramMessage.builder()
+                .text("some-text")
+                .chat(chat)
+                .from(user)
+                .build();
+
+        return TelegramUpdate.builder()
+                .message(message)
                 .build();
     }
 }

--- a/notification-service/src/test/java/com/jobflow/notification_service/jwt/JwtServiceImplTest.java
+++ b/notification-service/src/test/java/com/jobflow/notification_service/jwt/JwtServiceImplTest.java
@@ -1,9 +1,9 @@
-package com.jobflow.job_tracker_service.jwt;
+package com.jobflow.notification_service.jwt;
 
-import com.jobflow.job_tracker_service.TestUtil;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
+import org.junit.Before;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -11,8 +11,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.security.Key;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith(MockitoExtension.class)
 class JwtServiceImplTest {
@@ -22,12 +21,9 @@ class JwtServiceImplTest {
 
     private JwtServiceImpl jwtService;
 
-
     @BeforeEach
     public void setup() {
-        jwtService = new JwtServiceImpl(
-                SECRET_KEY
-        );
+        jwtService = new JwtServiceImpl(SECRET_KEY);
     }
 
     @Test

--- a/notification-service/src/test/java/com/jobflow/notification_service/telegram/TelegramControllerTest.java
+++ b/notification-service/src/test/java/com/jobflow/notification_service/telegram/TelegramControllerTest.java
@@ -1,0 +1,85 @@
+package com.jobflow.notification_service.telegram;
+
+import com.jobflow.notification_service.TestUtil;
+import com.jobflow.notification_service.exception.InvalidTelegramTokenException;
+import com.jobflow.notification_service.exception.UserClientException;
+import com.jobflow.notification_service.handler.GlobalHandler;
+import org.junit.experimental.results.ResultMatchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.testcontainers.shaded.com.fasterxml.jackson.core.JsonProcessingException;
+import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class TelegramControllerTest {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock
+    private TelegramService telegramService;
+
+    @InjectMocks
+    private TelegramController telegramController;
+
+    private MockMvc mockMvc;
+
+    private TelegramUpdate telegramUpdate;
+
+    private String telegramUpdateJson;
+
+    @BeforeEach
+    public void setup() throws JsonProcessingException {
+        mockMvc = MockMvcBuilders.standaloneSetup(telegramController)
+                .setControllerAdvice(new GlobalHandler())
+                .build();
+
+        telegramUpdate = TestUtil.createTelegramUpdate();
+        telegramUpdateJson = objectMapper.writeValueAsString(telegramUpdate);
+    }
+
+    @Test
+    public void receiveUpdate_returnOk() throws Exception {
+        doNothing().when(telegramService).processUpdate(telegramUpdate, "test-token");
+
+        mockMvc.perform(post("/api/v1/telegram/webhook")
+                        .header("X-Telegram-Bot-Api-Secret-Token", "test-token")
+                        .contentType(APPLICATION_JSON)
+                        .accept(APPLICATION_JSON)
+                        .content(telegramUpdateJson))
+                .andExpect(status().isOk());
+
+        verify(telegramService, times(1)).processUpdate(telegramUpdate, "test-token");
+    }
+
+    @Test
+    public void receiveUpdate_invalidToken_returnUnauthorized() throws Exception {
+        var invalidTokenExc = new InvalidTelegramTokenException("Invalid token");
+        doThrow(invalidTokenExc).when(telegramService).processUpdate(telegramUpdate, "test-token");
+
+        mockMvc.perform(post("/api/v1/telegram/webhook")
+                        .header("X-Telegram-Bot-Api-Secret-Token", "test-token")
+                        .contentType(APPLICATION_JSON)
+                        .accept(APPLICATION_JSON)
+                        .content(telegramUpdateJson))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.message").value(invalidTokenExc.getMessage()))
+                .andExpect(jsonPath("$.time").exists())
+                .andExpect(jsonPath("$.status").value(HttpStatus.UNAUTHORIZED.value()));
+
+        verify(telegramService, times(1)).processUpdate(telegramUpdate, "test-token");
+    }
+}

--- a/notification-service/src/test/java/com/jobflow/notification_service/telegram/TelegramIT.java
+++ b/notification-service/src/test/java/com/jobflow/notification_service/telegram/TelegramIT.java
@@ -1,0 +1,138 @@
+package com.jobflow.notification_service.telegram;
+
+import com.jobflow.notification_service.BaseIT;
+import com.jobflow.notification_service.JwtTestUtil;
+import com.jobflow.notification_service.TestUtil;
+import com.jobflow.notification_service.handler.ResponseError;
+import com.jobflow.notification_service.user.UserServiceProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.*;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.client.RestTemplate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.*;
+
+public class TelegramIT extends BaseIT {
+
+    @Autowired
+    private JwtTestUtil jwtTestUtil;
+
+    @Autowired
+    private TestRestTemplate testRestTemplate;
+
+    @Autowired
+    private UserServiceProperties userServiceProperties;
+
+    @MockitoBean
+    private RestTemplate restTemplate;
+
+    @Value("${telegram.bot.secret-token}")
+    private String token;
+
+    private TelegramUpdate telegramUpdate;
+
+    private String jwtToken;
+
+    @BeforeEach
+    public void setup() {
+        telegramUpdate = TestUtil.createTelegramUpdate();
+        jwtToken = jwtTestUtil.generateToken(1L);
+    }
+
+    @Test
+    public void receiveUpdate_successfullyLinkTelegram() {
+        telegramUpdate.getMessage().setText("/start " + jwtToken);
+        telegramUpdate.getMessage().getChat().setId(1L);
+        ArgumentCaptor<HttpEntity<TelegramChatLinkRequest>> captor = ArgumentCaptor.forClass(HttpEntity.class);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("X-Telegram-Bot-Api-Secret-Token", token);
+        HttpEntity<TelegramUpdate> request = TestUtil.createRequest(telegramUpdate, headers);
+
+        ResponseEntity<Void> response = testRestTemplate.exchange(
+                "/api/v1/telegram/webhook",
+                HttpMethod.POST,
+                request,
+                Void.class
+        );
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+
+        String url = String.format("http://%s:%s/api/v1/users",
+                userServiceProperties.getHost(), userServiceProperties.getPort()) + "/telegram";
+        verify(restTemplate, times(1)).exchange(
+                eq(url),
+                eq(HttpMethod.POST),
+                captor.capture(),
+                eq(Void.class)
+        );
+
+        HttpEntity<TelegramChatLinkRequest> linkRequest = captor.getValue();
+        TelegramChatLinkRequest linkBody = linkRequest.getBody();
+        assertNotNull(linkBody);
+        assertEquals(1L, linkBody.getUserId());
+        assertEquals(1L, linkBody.getChatId());
+
+        HttpHeaders linkHeaders = linkRequest.getHeaders();
+        assertEquals(userServiceProperties.getApiKey(), linkHeaders.getFirst("X-Api-Key"));
+    }
+
+    @Test
+    public void receiveUpdate_ifSomeExc_returnOk() {
+        telegramUpdate.getMessage().setText("/start " + jwtToken);
+        telegramUpdate.getMessage().getChat().setId(1L);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("X-Telegram-Bot-Api-Secret-Token", token);
+        HttpEntity<TelegramUpdate> request = TestUtil.createRequest(telegramUpdate, headers);
+
+        String url = String.format("http://%s:%s/api/v1/users",
+                userServiceProperties.getHost(), userServiceProperties.getPort()) + "/telegram";
+        var httpStatusCodeException = new HttpStatusCodeException(HttpStatus.UNAUTHORIZED) {};
+        when(restTemplate.exchange(
+                eq(url),
+                eq(HttpMethod.POST),
+                any(HttpEntity.class),
+                eq(Void.class)
+        )).thenThrow(httpStatusCodeException);
+
+        ResponseEntity<Void> response = testRestTemplate.exchange(
+                "/api/v1/telegram/webhook",
+                HttpMethod.POST,
+                request,
+                Void.class
+        );
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+    }
+
+    @Test
+    public void receiveUpdate_invalidTelegramToken_returnUnauthorized() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("X-Telegram-Bot-Api-Secret-Token", "invalid-token");
+        HttpEntity<TelegramUpdate> request = TestUtil.createRequest(telegramUpdate, headers);
+
+        ResponseEntity<ResponseError> response = testRestTemplate.exchange(
+                "/api/v1/telegram/webhook",
+                HttpMethod.POST,
+                request,
+                ResponseError.class
+        );
+
+        assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
+
+        ResponseError error = response.getBody();
+        assertNotNull(error);
+        assertEquals("Token: invalid-token invalid", error.getMessage());
+        assertEquals(HttpStatus.UNAUTHORIZED.value(), error.getStatus());
+        assertNotNull(error.getTime());
+    }
+}

--- a/notification-service/src/test/java/com/jobflow/notification_service/telegram/TelegramServiceImplTest.java
+++ b/notification-service/src/test/java/com/jobflow/notification_service/telegram/TelegramServiceImplTest.java
@@ -1,0 +1,97 @@
+package com.jobflow.notification_service.telegram;
+
+import com.jobflow.notification_service.TestUtil;
+import com.jobflow.notification_service.exception.InvalidTelegramTokenException;
+import com.jobflow.notification_service.exception.UserClientException;
+import com.jobflow.notification_service.jwt.JwtService;
+import com.jobflow.notification_service.user.UserClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class TelegramServiceImplTest {
+
+    @Mock
+    private JwtService jwtService;
+
+    @Mock
+    private UserClient userClient;
+
+    private static final String VALID_TOKEN = "test-token";
+
+    private TelegramServiceImpl telegramService;
+
+    private TelegramUpdate telegramUpdate;
+
+    @BeforeEach
+    public void setup() {
+        telegramService = new TelegramServiceImpl(jwtService, userClient, VALID_TOKEN);
+
+        telegramUpdate = TestUtil.createTelegramUpdate();
+    }
+
+    @Test
+    public void processUpdate_processUpdateSuccessfully() {
+        telegramUpdate.getMessage().setText("/start some-token");
+        telegramUpdate.getMessage().getChat().setId(1L);
+        when(jwtService.extractUserId("some-token")).thenReturn("1");
+
+        telegramService.processUpdate(telegramUpdate, VALID_TOKEN);
+
+        verify(userClient, times(1)).linkChatId(1L, 1L);
+    }
+
+    @Test
+    public void processUpdate_messageIsNull_skipUpdate() {
+        telegramUpdate.setMessage(null);
+
+        telegramService.processUpdate(telegramUpdate, VALID_TOKEN);
+
+        verifyNoInteractions(jwtService, userClient);
+    }
+
+    @Test
+    public void processUpdate_messageTestIsNull_skipUpdate() {
+        telegramUpdate.getMessage().setText(null);
+
+        telegramService.processUpdate(telegramUpdate, VALID_TOKEN);
+
+        verifyNoInteractions(jwtService, userClient);
+    }
+
+    @Test
+    public void processUpdate_textDoesNotStartsWithStart_skipUpdate() {
+        telegramUpdate.getMessage().setText("some-token");
+
+        telegramService.processUpdate(telegramUpdate, VALID_TOKEN);
+
+        verifyNoInteractions(jwtService, userClient);
+    }
+
+    @Test
+    public void processUpdate_invalidToken_throwExc() {
+        var invalidTelegramTokenException = assertThrows(InvalidTelegramTokenException.class,
+                () -> telegramService.processUpdate(telegramUpdate, "invalid-token"));
+
+        assertEquals("Token: invalid-token invalid", invalidTelegramTokenException.getMessage());
+    }
+
+    @Test
+    public void processUpdate_ifExc_doesNotThrowAnything() {
+        telegramUpdate.getMessage().setText("/start some-token");
+        telegramUpdate.getMessage().getChat().setId(1L);
+        when(jwtService.extractUserId("some-token")).thenReturn("1");
+
+        var userClientException = new UserClientException("User client exception");
+        doThrow(userClientException).when(userClient).linkChatId(1L, 1L);
+
+        assertDoesNotThrow(() -> telegramService.processUpdate(telegramUpdate, VALID_TOKEN));
+    }
+
+}

--- a/notification-service/src/test/resources/application.properties
+++ b/notification-service/src/test/resources/application.properties
@@ -4,6 +4,8 @@ spring.rabbitmq.exchange-name=notification.exchange
 spring.rabbitmq.email-queue-routing-key=notification.email.queue
 spring.rabbitmq.telegram-queue-routing-key=notification.telegram.queue
 
+jwt.secret-key=d1V6OXhGSnR2TFlFN01mdVhnaHFrZTBSakh6QWRCWVE
+
 spring.mail.host=smtp.gmail.com
 spring.mail.port=587
 spring.mail.username=test-username
@@ -13,3 +15,5 @@ spring.mail.protocol=smtp
 user.service.host=localhost
 user.service.port=8080
 user.service.api-key=test-key
+
+telegram.bot.secret-token=test-token

--- a/user-service/src/main/java/com/jobflow/user_service/security/SecurityConfig.java
+++ b/user-service/src/main/java/com/jobflow/user_service/security/SecurityConfig.java
@@ -33,7 +33,7 @@ public class SecurityConfig {
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .authorizeHttpRequests(httpReq -> httpReq
                         .requestMatchers("/api/v1/auth","/api/v1/auth/refresh", "/api/v1/register/**", "/api/v1/openid/**").permitAll()
-                        .requestMatchers("/api/v1/users/info").permitAll()
+                        .requestMatchers("/api/v1/users/info", "/api/v1/users/telegram").permitAll()
                         .requestMatchers("/actuator/**").permitAll()
                         .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**").permitAll()
                         .anyRequest().authenticated())

--- a/user-service/src/main/java/com/jobflow/user_service/user/TelegramChatLinkRequest.java
+++ b/user-service/src/main/java/com/jobflow/user_service/user/TelegramChatLinkRequest.java
@@ -1,0 +1,25 @@
+package com.jobflow.user_service.user;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = """
+        A dto representing information for linking a user to a telegram chat.
+        It is used for micro-service interaction
+        """)
+public class TelegramChatLinkRequest {
+
+    @Schema(description = "User ID", example = "1")
+    private Long userId;
+
+    @Schema(description = "Telegram chat ID", example = "1")
+    private Long chatId;
+}

--- a/user-service/src/main/java/com/jobflow/user_service/user/User.java
+++ b/user-service/src/main/java/com/jobflow/user_service/user/User.java
@@ -50,6 +50,9 @@ public class User implements UserDetails {
     @Column(name = "auth_provider_id", length = 255)
     private String authProviderId;
 
+    @Column(name = "telegram_chat_id", unique = true)
+    private Long telegramChatId;
+
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return List.of(new SimpleGrantedAuthority(role.name()));

--- a/user-service/src/main/java/com/jobflow/user_service/user/UserController.java
+++ b/user-service/src/main/java/com/jobflow/user_service/user/UserController.java
@@ -1,6 +1,5 @@
 package com.jobflow.user_service.user;
 
-import com.jobflow.user_service.auth.AuthenticationResponse;
 import com.jobflow.user_service.handler.ResponseError;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -8,7 +7,6 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,5 +48,37 @@ public class UserController {
         LOGGER.info("[GET] Request for get user info by id: {}", userId);
 
         return ResponseEntity.ok(userService.getUserInfo(userId, apiKey));
+    }
+
+    @Operation(
+            summary = "Link telegram",
+            description = "Linking user with telegram chat. It is used for micro-service interaction",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Telegram linked successfully",
+                            content = @Content(mediaType = "application/json", schema =
+                            @Schema(implementation = Void.class))),
+
+                    @ApiResponse(responseCode = "404", description = "User with this ID not found",
+                            content = @Content(mediaType = "application/json", schema =
+                            @Schema(implementation = ResponseError.class))),
+
+                    @ApiResponse(responseCode = "401", description = "Authentication exception, e.g incorrect api key",
+                            content = @Content(mediaType = "application/json", schema =
+                            @Schema(implementation = ResponseError.class)))
+            }
+    )
+    @PostMapping("/telegram")
+    public ResponseEntity<Void> linkTelegram(
+            @RequestHeader("X-API-Key") @Parameter(in = ParameterIn.HEADER,
+                    description = "Api key", example = "api-key", required = true) String apiKey,
+            @RequestBody @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "Telegram chat link details", required = true
+            ) TelegramChatLinkRequest linkRequest
+    ) {
+        LOGGER.info("[POST] Linking telegram request received. chatId: {}, userId: {}",
+                linkRequest.getChatId(), linkRequest.getUserId());
+        userService.linkTelegram(linkRequest, apiKey);
+
+        return ResponseEntity.ok().build();
     }
 }

--- a/user-service/src/main/java/com/jobflow/user_service/user/UserInfoDto.java
+++ b/user-service/src/main/java/com/jobflow/user_service/user/UserInfoDto.java
@@ -17,5 +17,5 @@ public class UserInfoDto {
     private String email;
 
     @Schema(description = "Telegram chat ID", example = "123")
-    private String telegramChatId;
+    private Long telegramChatId;
 }

--- a/user-service/src/main/java/com/jobflow/user_service/user/UserRepository.java
+++ b/user-service/src/main/java/com/jobflow/user_service/user/UserRepository.java
@@ -13,5 +13,4 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByAuthProviderAndAuthProviderId(AuthProvider provider, String authProviderId);
 
     boolean existsByLogin(String login);
-
 }

--- a/user-service/src/main/java/com/jobflow/user_service/user/UserService.java
+++ b/user-service/src/main/java/com/jobflow/user_service/user/UserService.java
@@ -5,4 +5,6 @@ public interface UserService {
     User getCurrentUser();
 
     UserInfoDto getUserInfo(Long userId, String apiKey);
+
+    void linkTelegram(TelegramChatLinkRequest linkRequest, String apiKey);
 }

--- a/user-service/src/main/java/com/jobflow/user_service/user/UserServiceImpl.java
+++ b/user-service/src/main/java/com/jobflow/user_service/user/UserServiceImpl.java
@@ -16,9 +16,8 @@ public class UserServiceImpl implements UserService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(UserServiceImpl.class);
 
-    private UserRepository userRepository;
-
-    private String apiKey;
+    private final UserRepository userRepository;
+    private final String apiKey;
 
     public UserServiceImpl(UserRepository userRepository,
                            @Value("${notification.service.api-key}") String apiKey) {
@@ -43,17 +42,49 @@ public class UserServiceImpl implements UserService {
     public UserInfoDto getUserInfo(Long userId, String apiKey) {
         LOGGER.debug("Fetching user info by id: {}", userId);
 
-        if (!this.apiKey.equals(apiKey)) {
-            throw new InvalidApiKeyException("Api key: " + apiKey + " invalid");
-        }
+        validateApikey(apiKey);
 
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new UserNotFoundException("User with id: " + userId + " not found"));
+        User user = findByIdOrThrow(userId);
 
         LOGGER.debug("Successfully fetched user info by id: {}", userId);
         return UserInfoDto.builder()
                 .email(user.getLogin())
-                .telegramChatId(null)
+                .telegramChatId(user.getTelegramChatId())
                 .build();
+    }
+
+    @Override
+    public void linkTelegram(TelegramChatLinkRequest linkRequest, String apiKey) {
+        LOGGER.debug("Starting telegram linking for chatId: {} and userId: {}",
+                linkRequest.getChatId(), linkRequest.getUserId());
+
+        validateApikey(apiKey);
+
+        Long userId = linkRequest.getUserId();
+        Long chatId = linkRequest.getChatId();
+
+        User user = findByIdOrThrow(userId);
+
+        if (user.getTelegramChatId() == null) {
+            user.setTelegramChatId(chatId);
+
+            userRepository.save(user);
+
+            LOGGER.debug("Successfully telegram linking for chatId: {} and userId: {}",
+                    chatId, userId);
+        } else {
+            LOGGER.debug("Telegram chat id is already linked with a user with userId: {}", userId);
+        }
+    }
+
+    private User findByIdOrThrow(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException("User with id: " + userId + " not found"));
+    }
+
+    private void validateApikey(String apiKey) {
+        if (!this.apiKey.equals(apiKey)) {
+            throw new InvalidApiKeyException("Api key: " + apiKey + " invalid");
+        }
     }
 }

--- a/user-service/src/test/java/com/jobflow/user_service/TestUtil.java
+++ b/user-service/src/test/java/com/jobflow/user_service/TestUtil.java
@@ -4,14 +4,11 @@ import com.jobflow.user_service.auth.AuthenticationRequest;
 import com.jobflow.user_service.auth.LogoutRequest;
 import com.jobflow.user_service.auth.RefreshTokenRequest;
 import com.jobflow.user_service.openId.OpenIdUserInfo;
-import com.jobflow.user_service.user.AuthProvider;
+import com.jobflow.user_service.user.*;
 import com.jobflow.user_service.openId.OpenIdRequest;
 import com.jobflow.user_service.register.ConfirmCodeRequest;
 import com.jobflow.user_service.register.RegisterRequest;
 import com.jobflow.user_service.register.ResendCodeRequest;
-import com.jobflow.user_service.user.Role;
-import com.jobflow.user_service.user.User;
-import com.jobflow.user_service.user.UserInfoDto;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.util.LinkedMultiValueMap;
@@ -113,13 +110,21 @@ public final class TestUtil {
                 .password(PASSWORD)
                 .role(Role.ROLE_USER)
                 .authProvider(AuthProvider.LOCAL)
+                .telegramChatId(1L)
                 .build();
     }
 
     public static UserInfoDto createUserInfo() {
         return UserInfoDto.builder()
                 .email(LOGIN)
-                .telegramChatId("123")
+                .telegramChatId(1L)
+                .build();
+    }
+
+    public static TelegramChatLinkRequest createLinkRequest() {
+        return TelegramChatLinkRequest.builder()
+                .userId(Long.valueOf(USER_ID))
+                .chatId(1L)
                 .build();
     }
 }

--- a/user-service/src/test/java/com/jobflow/user_service/user/UserControllerTest.java
+++ b/user-service/src/test/java/com/jobflow/user_service/user/UserControllerTest.java
@@ -13,15 +13,20 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.testcontainers.shaded.com.fasterxml.jackson.core.JsonProcessingException;
+import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 
 import static org.mockito.Mockito.*;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(MockitoExtension.class)
 class UserControllerTest {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
 
     @Mock
     private UserService userService;
@@ -33,13 +38,20 @@ class UserControllerTest {
 
     private UserInfoDto userInfo;
 
+    private TelegramChatLinkRequest linkRequest;
+
+    private String linkRequestJson;
+
     @BeforeEach
-    public void setup() {
+    public void setup() throws JsonProcessingException {
         mockMvc = MockMvcBuilders.standaloneSetup(userController)
                 .setControllerAdvice(new GlobalHandler())
                 .build();
 
         userInfo = TestUtil.createUserInfo();
+
+        linkRequest = TestUtil.createLinkRequest();
+        linkRequestJson = objectMapper.writeValueAsString(linkRequest);
     }
 
     @Test
@@ -92,5 +104,55 @@ class UserControllerTest {
                 .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()));
 
         verify(userService, times(1)).getUserInfo(1L, "test-key");
+    }
+
+    @Test
+    public void linkTelegram_returnOk() throws Exception {
+        doNothing().when(userService).linkTelegram(linkRequest, "test-key");
+
+        mockMvc.perform(post("/api/v1/users/telegram")
+                        .header("X-API-Key", "test-key")
+                        .contentType(APPLICATION_JSON)
+                        .accept(APPLICATION_JSON)
+                        .content(linkRequestJson))
+                .andExpect(status().isOk());
+
+        verify(userService, times(1)).linkTelegram(linkRequest, "test-key");
+    }
+
+    @Test
+    public void linkTelegram_invalidApiKey_returnUnauthorized() throws Exception {
+        var invalidApiKeyExc = new InvalidApiKeyException("Invalid api key");
+        doThrow(invalidApiKeyExc).when(userService).linkTelegram(linkRequest, "test-key");
+
+        mockMvc.perform(post("/api/v1/users/telegram")
+                        .header("X-API-Key", "test-key")
+                        .contentType(APPLICATION_JSON)
+                        .accept(APPLICATION_JSON)
+                        .content(linkRequestJson))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.message").value(invalidApiKeyExc.getMessage()))
+                .andExpect(jsonPath("$.time").exists())
+                .andExpect(jsonPath("$.status").value(HttpStatus.UNAUTHORIZED.value()));
+
+        verify(userService, times(1)).linkTelegram(linkRequest, "test-key");
+    }
+
+    @Test
+    public void linkTelegram_userNotFound_returnNotFound() throws Exception {
+        var userNotFoundException = new UserNotFoundException("User not found");
+        doThrow(userNotFoundException).when(userService).linkTelegram(linkRequest, "test-key");
+
+        mockMvc.perform(post("/api/v1/users/telegram")
+                        .header("X-API-Key", "test-key")
+                        .contentType(APPLICATION_JSON)
+                        .accept(APPLICATION_JSON)
+                        .content(linkRequestJson))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value(userNotFoundException.getMessage()))
+                .andExpect(jsonPath("$.time").exists())
+                .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()));
+
+        verify(userService, times(1)).linkTelegram(linkRequest, "test-key");
     }
 }

--- a/user-service/src/test/java/com/jobflow/user_service/user/UserIT.java
+++ b/user-service/src/test/java/com/jobflow/user_service/user/UserIT.java
@@ -12,6 +12,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.*;
 
+import java.util.Optional;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 public class UserIT extends BaseIT {
@@ -27,11 +29,15 @@ public class UserIT extends BaseIT {
 
     private User user;
 
+    private TelegramChatLinkRequest linkRequest;
+
     @BeforeEach
     public void setup() {
         userRepository.deleteAll();
 
         user = TestUtil.createUser();
+
+        linkRequest = TestUtil.createLinkRequest();
     }
 
     @Test
@@ -55,7 +61,7 @@ public class UserIT extends BaseIT {
         UserInfoDto responseBody = response.getBody();
         assertNotNull(responseBody);
         assertEquals(user.getLogin(), responseBody.getEmail());
-        assertNull(responseBody.getTelegramChatId());
+        assertEquals(user.getTelegramChatId(), responseBody.getTelegramChatId());
     }
 
     @Test
@@ -89,6 +95,97 @@ public class UserIT extends BaseIT {
         ResponseEntity<ResponseError> response = restTemplate.exchange(
                 "/api/v1/users/info?userId=999",
                 HttpMethod.GET,
+                request,
+                ResponseError.class
+        );
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+
+        ResponseError error = response.getBody();
+        assertNotNull(error);
+        assertEquals("User with id: 999 not found", error.getMessage());
+        assertEquals(HttpStatus.NOT_FOUND.value(), error.getStatus());
+        assertNotNull(error.getTime());
+    }
+
+    @Test
+    public void linkTelegram_linkTelegramSuccessfully() {
+        user.setId(null);
+        user.setTelegramChatId(null);
+        User savedUser = userRepository.save(user);
+        linkRequest.setUserId(savedUser.getId());
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("X-API-Key", apiKey);
+        HttpEntity<TelegramChatLinkRequest> request = TestUtil.createRequest(linkRequest, headers);
+
+        ResponseEntity<Void> response = restTemplate.exchange(
+                "/api/v1/users/telegram",
+                HttpMethod.POST,
+                request,
+                Void.class
+        );
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        User userFromDb = userRepository.findById(savedUser.getId()).get();
+        assertEquals(linkRequest.getChatId(), userFromDb.getTelegramChatId());
+    }
+
+    @Test
+    public void linkTelegram_alreadyLinked_doesNotLink() {
+        user.setId(null);
+        user.setTelegramChatId(999L);
+        User savedUser = userRepository.save(user);
+        linkRequest.setUserId(savedUser.getId());
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("X-API-Key", apiKey);
+        HttpEntity<TelegramChatLinkRequest> request = TestUtil.createRequest(linkRequest, headers);
+
+        ResponseEntity<Void> response = restTemplate.exchange(
+                "/api/v1/users/telegram",
+                HttpMethod.POST,
+                request,
+                Void.class
+        );
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        User userFromDb = userRepository.findById(savedUser.getId()).get();
+        assertEquals(999L, userFromDb.getTelegramChatId());
+    }
+
+    @Test
+    public void linkTelegram_invalidApiKey_returnUnauthorized() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("X-API-Key", "invalid-key");
+        HttpEntity<TelegramChatLinkRequest> request = TestUtil.createRequest(linkRequest, headers);
+
+        ResponseEntity<ResponseError> response = restTemplate.exchange(
+                "/api/v1/users/telegram",
+                HttpMethod.POST,
+                request,
+                ResponseError.class
+        );
+
+        assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
+
+        ResponseError error = response.getBody();
+        assertNotNull(error);
+        assertEquals("Api key: invalid-key invalid", error.getMessage());
+        assertEquals(HttpStatus.UNAUTHORIZED.value(), error.getStatus());
+        assertNotNull(error.getTime());
+    }
+
+    @Test
+    public void linkTelegram_userNotFound_returnNotFound() {
+        linkRequest.setUserId(999L);
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("X-API-Key", apiKey);
+        HttpEntity<TelegramChatLinkRequest> request = TestUtil.createRequest(linkRequest, headers);
+
+        ResponseEntity<ResponseError> response = restTemplate.exchange(
+                "/api/v1/users/telegram",
+                HttpMethod.POST,
                 request,
                 ResponseError.class
         );


### PR DESCRIPTION
- Implemented the Telegram webhook endpoint to send messages from a telegram bot configured for this webhook, created through the Telegram Bot API
- Implemented the logic of processing a webhook request, with sending a link request to a user-service to connect a telegram chat id with a user id
- Implemented the endpoint and logic in the user-service for the telegram chat id and user id link
- Implemented the jwt service to validate the jwt token sent to the bot in messages
- Covered with unit and integration tests
- Integrated Swagger documentation