### PR TITLE
Merge feature/retryable-and-dlq into develop

### DIFF
--- a/job-tracker-service/Dockerfile
+++ b/job-tracker-service/Dockerfile
@@ -1,15 +1,15 @@
-#FROM maven:latest AS builder
-#WORKDIR /app
-#COPY . .
-#RUN mvn clean package -DskipTests
-#
-#FROM openjdk:latest
-#WORKDIR /app
-#COPY --from=builder /app/target/job-tracker-service-0.0.1-SNAPSHOT.jar app.jar
-#ENTRYPOINT ["java", "-jar", "/app/app.jar"]
+FROM maven:latest AS builder
+WORKDIR /app
+COPY . .
+RUN mvn clean package -DskipTests
 
 FROM openjdk:latest
 WORKDIR /app
-COPY /target/job-tracker-service-0.0.1-SNAPSHOT.jar /app/app.jar
-ENTRYPOINT ["java", "-jar", "app.jar"]
+COPY --from=builder /app/target/job-tracker-service-0.0.1-SNAPSHOT.jar app.jar
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]
+
+#FROM openjdk:latest
+#WORKDIR /app
+#COPY /target/job-tracker-service-0.0.1-SNAPSHOT.jar /app/app.jar
+#ENTRYPOINT ["java", "-jar", "app.jar"]
 

--- a/job-tracker-service/src/main/java/com/jobflow/job_tracker_service/rabbitMQ/RabbitConfiguration.java
+++ b/job-tracker-service/src/main/java/com/jobflow/job_tracker_service/rabbitMQ/RabbitConfiguration.java
@@ -10,6 +10,8 @@ import org.springframework.amqp.support.converter.MessageConverter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.util.Map;
+
 @Configuration
 @RequiredArgsConstructor
 public class RabbitConfiguration {
@@ -43,17 +45,42 @@ public class RabbitConfiguration {
 
     @Bean
     public Queue emailQueue() {
-        return new Queue(rabbitProperties.getEmailQueueName(), true);
+        Map<String, Object> args = Map.of(
+                "x-dead-letter-exchange", rabbitProperties.getDleName(),
+                "x-dead-letter-routing-key", rabbitProperties.getEmailDlqRoutingKey()
+        );
+
+        return new Queue(rabbitProperties.getEmailQueueName(), true, false, false, args);
     }
 
     @Bean
     public Queue telegramQueue() {
-        return new Queue(rabbitProperties.getTelegramQueueName(), true);
+        Map<String, Object> args = Map.of(
+                "x-dead-letter-exchange", rabbitProperties.getDleName(),
+                "x-dead-letter-routing-key", rabbitProperties.getTelegramDlqRoutingKey()
+        );
+
+        return new Queue(rabbitProperties.getTelegramQueueName(), true, false, false, args);
+    }
+
+    @Bean
+    public Queue emailDlq() {
+        return new Queue(rabbitProperties.getEmailDlqName(), true);
+    }
+
+    @Bean
+    public Queue telegramDlq() {
+        return new Queue(rabbitProperties.getTelegramDlqName(), true);
     }
 
     @Bean
     public Exchange exchange() {
         return new DirectExchange(rabbitProperties.getExchangeName(), true, false);
+    }
+
+    @Bean
+    public Exchange dle() {
+        return new DirectExchange(rabbitProperties.getDleName(), true, false);
     }
 
     @Bean
@@ -71,6 +98,24 @@ public class RabbitConfiguration {
                 .bind(telegramQueue())
                 .to(exchange())
                 .with(rabbitProperties.getTelegramQueueRoutingKey())
+                .noargs();
+    }
+
+    @Bean
+    public Binding emailDlqBinding() {
+        return BindingBuilder
+                .bind(emailDlq())
+                .to(dle())
+                .with(rabbitProperties.getEmailDlqRoutingKey())
+                .noargs();
+    }
+
+    @Bean
+    public Binding telegramDlqBinding() {
+        return BindingBuilder
+                .bind(telegramDlq())
+                .to(dle())
+                .with(rabbitProperties.getTelegramDlqRoutingKey())
                 .noargs();
     }
 }

--- a/job-tracker-service/src/main/java/com/jobflow/job_tracker_service/rabbitMQ/RabbitProperties.java
+++ b/job-tracker-service/src/main/java/com/jobflow/job_tracker_service/rabbitMQ/RabbitProperties.java
@@ -12,20 +12,20 @@ import org.springframework.stereotype.Component;
 public class RabbitProperties {
 
     private String host;
-
     private String port;
-
     private String username;
-
     private String password;
 
     private String exchangeName;
+    private String dleName;
 
     private String emailQueueName;
-
     private String telegramQueueName;
+    private String emailDlqName;
+    private String telegramDlqName;
 
     private String emailQueueRoutingKey;
-
     private String telegramQueueRoutingKey;
+    private String emailDlqRoutingKey;
+    private String telegramDlqRoutingKey;
 }

--- a/job-tracker-service/src/main/resources/application.properties
+++ b/job-tracker-service/src/main/resources/application.properties
@@ -23,8 +23,16 @@ spring.rabbitmq.host=${RABBITMQ_HOST}
 spring.rabbitmq.port=${RABBITMQ_PORT}
 spring.rabbitmq.username=${RABBITMQ_USERNAME}
 spring.rabbitmq.password=${RABBITMQ_PASSWORD}
+
 spring.rabbitmq.exchange-name=notification.exchange
+spring.rabbitmq.dle-name=notification.dle
+
 spring.rabbitmq.email-queue-name=notification.email.queue
 spring.rabbitmq.telegram-queue-name=notification.telegram.queue
+spring.rabbitmq.email-dlq-name=notification.email.dlq
+spring.rabbitmq.telegram-dlq-name=notification.telegram.dlq
+
 spring.rabbitmq.email-queue-routing-key=notification.email.queue
 spring.rabbitmq.telegram-queue-routing-key=notification.telegram.queue
+spring.rabbitmq.email-dlq-routing-key=notification.email.dlq
+spring.rabbitmq.telegram-dlq-routing-key=notification.telegram.dlq

--- a/notification-service/Dockerfile
+++ b/notification-service/Dockerfile
@@ -1,14 +1,14 @@
-#FROM maven:latest AS builder
-#WORKDIR /app
-#COPY . .
-#RUN mvn clean package -DskipTests
-#
-#FROM openjdk:latest
-#WORKDIR /app
-#COPY --from=builder /app/target/notification-service-0.0.1-SNAPSHOT.jar app.jar
-#ENTRYPOINT ["java", "-jar", "/app/app.jar"]
+FROM maven:latest AS builder
+WORKDIR /app
+COPY . .
+RUN mvn clean package -DskipTests
 
 FROM openjdk:latest
 WORKDIR /app
-COPY /target/notification-service-0.0.1-SNAPSHOT.jar /app/app.jar
-ENTRYPOINT ["java", "-jar", "app.jar"]
+COPY --from=builder /app/target/notification-service-0.0.1-SNAPSHOT.jar app.jar
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]
+
+#FROM openjdk:latest
+#WORKDIR /app
+#COPY /target/notification-service-0.0.1-SNAPSHOT.jar /app/app.jar
+#ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/notification-service/docker-compose.yml
+++ b/notification-service/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       start_period: 10s
     restart: always
 
-  jobflow-notificat ion-db:
+  jobflow-notification-db:
     image: postgres:latest
     container_name: jobflow-notification-db
     networks:

--- a/notification-service/pom.xml
+++ b/notification-service/pom.xml
@@ -72,6 +72,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.retry</groupId>
+            <artifactId>spring-retry</artifactId>
+            <version>2.0.12</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <version>42.7.5</version>

--- a/notification-service/src/main/java/com/jobflow/notification_service/NotificationServiceApplication.java
+++ b/notification-service/src/main/java/com/jobflow/notification_service/NotificationServiceApplication.java
@@ -2,8 +2,10 @@ package com.jobflow.notification_service;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.retry.annotation.EnableRetry;
 
 @SpringBootApplication
+@EnableRetry
 public class NotificationServiceApplication {
     
     public static void main(String[] args) {

--- a/notification-service/src/main/java/com/jobflow/notification_service/exception/NotificationException.java
+++ b/notification-service/src/main/java/com/jobflow/notification_service/exception/NotificationException.java
@@ -1,0 +1,12 @@
+package com.jobflow.notification_service.exception;
+
+public class NotificationException extends RuntimeException {
+
+    public NotificationException(String message) {
+        super(message);
+    }
+
+    public NotificationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/notification-service/src/main/java/com/jobflow/notification_service/notification/AbstractNotificationService.java
+++ b/notification-service/src/main/java/com/jobflow/notification_service/notification/AbstractNotificationService.java
@@ -1,5 +1,6 @@
 package com.jobflow.notification_service.notification;
 
+import com.jobflow.notification_service.exception.NotificationException;
 import com.jobflow.notification_service.notification.history.NotificationHistoryService;
 import com.jobflow.notification_service.user.UserClient;
 import com.jobflow.notification_service.user.UserInfo;
@@ -40,6 +41,8 @@ public abstract class AbstractNotificationService<C> {
                     userId, e.getMessage());
 
             historyService.save(notificationEvent, notificationType, false, e.getMessage());
+
+            throw new NotificationException("Failed to sending notification event: " + e.getMessage(), e);
         }
     }
 

--- a/notification-service/src/main/java/com/jobflow/notification_service/notification/EmailNotificationService.java
+++ b/notification-service/src/main/java/com/jobflow/notification_service/notification/EmailNotificationService.java
@@ -5,6 +5,7 @@ import com.jobflow.notification_service.notification.history.NotificationHistory
 import com.jobflow.notification_service.notification.history.NotificationHistoryService;
 import com.jobflow.notification_service.user.UserClient;
 import com.jobflow.notification_service.user.UserInfo;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 
 @Service

--- a/notification-service/src/main/java/com/jobflow/notification_service/rabbitMQ/RabbitAbstractConsumer.java
+++ b/notification-service/src/main/java/com/jobflow/notification_service/rabbitMQ/RabbitAbstractConsumer.java
@@ -3,4 +3,5 @@ package com.jobflow.notification_service.rabbitMQ;
 public abstract class RabbitAbstractConsumer<T> {
 
     public abstract void consume(T payload);
+
 }

--- a/notification-service/src/main/java/com/jobflow/notification_service/rabbitMQ/RabbitEmailConsumer.java
+++ b/notification-service/src/main/java/com/jobflow/notification_service/rabbitMQ/RabbitEmailConsumer.java
@@ -1,17 +1,25 @@
 package com.jobflow.notification_service.rabbitMQ;
 
+import com.jobflow.notification_service.exception.NotificationException;
 import com.jobflow.notification_service.notification.AbstractNotificationService;
 import com.jobflow.notification_service.notification.NotificationEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 
 @Service
 public class RabbitEmailConsumer extends RabbitNotificationConsumer {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RabbitEmailConsumer.class);
+
+    @Value("${spring.rabbitmq.retryable-max-attempts}")
+    private int maxAttempts;
 
     public RabbitEmailConsumer(
             @Qualifier("emailNotificationService") AbstractNotificationService<?> notificationService
@@ -20,10 +28,27 @@ public class RabbitEmailConsumer extends RabbitNotificationConsumer {
     }
 
     @RabbitListener(queues = {"${spring.rabbitmq.email-queue-name}"})
+    @Retryable(
+            retryFor = NotificationException.class,
+            maxAttemptsExpression = "${spring.rabbitmq.retryable-max-attempts}",
+            recover = "recover",
+            backoff = @Backoff(
+                    delayExpression = "${spring.rabbitmq.retryable-delay}"
+            )
+
+    )
     @Override
     public void consume(NotificationEvent notificationEvent) {
         LOGGER.debug("Consuming notification event from Email queue: {}", notificationEvent);
 
         notificationService.send(notificationEvent);
+    }
+
+    @Recover
+    public void recover(NotificationException exc, NotificationEvent payload) {
+        LOGGER.debug("Failed to sending notification event: {} after {} retries. Sending to email DLQ. Reason: {}",
+                payload, maxAttempts, exc.getMessage());
+
+        throw exc;
     }
 }

--- a/notification-service/src/main/java/com/jobflow/notification_service/rabbitMQ/RabbitNotificationConsumer.java
+++ b/notification-service/src/main/java/com/jobflow/notification_service/rabbitMQ/RabbitNotificationConsumer.java
@@ -8,4 +8,5 @@ import lombok.RequiredArgsConstructor;
 public abstract class RabbitNotificationConsumer extends RabbitAbstractConsumer<NotificationEvent> {
 
     protected final AbstractNotificationService<?> notificationService;
+
 }

--- a/notification-service/src/main/java/com/jobflow/notification_service/rabbitMQ/RabbitProperties.java
+++ b/notification-service/src/main/java/com/jobflow/notification_service/rabbitMQ/RabbitProperties.java
@@ -12,21 +12,25 @@ import org.springframework.stereotype.Component;
 public class RabbitProperties {
 
     private String host;
-
     private String port;
-
     private String username;
-
     private String password;
 
     private String exchangeName;
+    private String dleName;
 
     private String emailQueueName;
-
     private String telegramQueueName;
+    private String emailDlqName;
+    private String telegramDlqName;
 
     private String emailQueueRoutingKey;
-
     private String telegramQueueRoutingKey;
+    private String emailDlqRoutingKey;
+    private String telegramDlqRoutingKey;
+
+    private String retryableMaxAttempts;
+    private String retryableDelay;
+
 }
 

--- a/notification-service/src/main/java/com/jobflow/notification_service/rabbitMQ/RabbitTelegramConsumer.java
+++ b/notification-service/src/main/java/com/jobflow/notification_service/rabbitMQ/RabbitTelegramConsumer.java
@@ -1,17 +1,25 @@
 package com.jobflow.notification_service.rabbitMQ;
 
+import com.jobflow.notification_service.exception.NotificationException;
 import com.jobflow.notification_service.notification.AbstractNotificationService;
 import com.jobflow.notification_service.notification.NotificationEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 
 @Service
 public class RabbitTelegramConsumer extends RabbitNotificationConsumer {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RabbitTelegramConsumer.class);
+
+    @Value("${spring.rabbitmq.retryable-max-attempts}")
+    private int maxAttempts;
 
     public RabbitTelegramConsumer(
             @Qualifier("telegramNotificationService") AbstractNotificationService<?> notificationService
@@ -20,10 +28,27 @@ public class RabbitTelegramConsumer extends RabbitNotificationConsumer {
     }
 
     @RabbitListener(queues = {"${spring.rabbitmq.telegram-queue-name}"})
+    @Retryable(
+            retryFor = NotificationException.class,
+            maxAttemptsExpression = "${spring.rabbitmq.retryable-max-attempts}",
+            recover = "recover",
+            backoff = @Backoff(
+                    delayExpression = "${spring.rabbitmq.retryable-delay}"
+            )
+
+    )
     @Override
     public void consume(NotificationEvent notificationEvent) {
         LOGGER.debug("Consuming notification event from Telegram queue: {}", notificationEvent);
 
         notificationService.send(notificationEvent);
+    }
+
+    @Recover
+    public void recover(NotificationException exc, NotificationEvent payload) {
+        LOGGER.debug("Failed to sending notification event: {} after {} retries. Sending to telegram DLQ. Reason: {}",
+                payload, maxAttempts, exc.getMessage());
+
+        throw exc;
     }
 }

--- a/notification-service/src/main/resources/application.properties
+++ b/notification-service/src/main/resources/application.properties
@@ -12,11 +12,22 @@ spring.rabbitmq.host=${RABBITMQ_HOST}
 spring.rabbitmq.port=${RABBITMQ_PORT}
 spring.rabbitmq.username=${RABBITMQ_USERNAME}
 spring.rabbitmq.password=${RABBITMQ_PASSWORD}
+
+spring.rabbitmq.exchange-name=notification.exchange
+spring.rabbitmq.dle-name=notification.dle
+
 spring.rabbitmq.email-queue-name=notification.email.queue
 spring.rabbitmq.telegram-queue-name=notification.telegram.queue
-spring.rabbitmq.exchange-name=notification.exchange
+spring.rabbitmq.email-dlq-name=notification.email.dlq
+spring.rabbitmq.telegram-dlq-name=notification.telegram.dlq
+
 spring.rabbitmq.email-queue-routing-key=notification.email.queue
 spring.rabbitmq.telegram-queue-routing-key=notification.telegram.queue
+spring.rabbitmq.email-dlq-routing-key=notification.email.dlq
+spring.rabbitmq.telegram-dlq-routing-key=notification.telegram.dlq
+
+spring.rabbitmq.retryable-max-attempts=3
+spring.rabbitmq.retryable-delay=3000
 
 spring.datasource.driver-class-name=org.postgresql.Driver
 spring.datasource.url=${POSTGRES_URL}

--- a/notification-service/src/test/java/com/jobflow/notification_service/TestUtil.java
+++ b/notification-service/src/test/java/com/jobflow/notification_service/TestUtil.java
@@ -9,6 +9,7 @@ import com.jobflow.notification_service.telegram.TelegramMessage;
 import com.jobflow.notification_service.telegram.TelegramUpdate;
 import com.jobflow.notification_service.telegram.TelegramUser;
 import com.jobflow.notification_service.user.UserInfo;
+import org.springframework.amqp.core.AmqpAdmin;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -88,6 +89,10 @@ public final class TestUtil {
                 .failureReason(null)
                 .createdAt(LocalDateTime.now())
                 .build();
+    }
+
+    public static void clearRabbit(AmqpAdmin amqpAdmin, String queueName) {
+        amqpAdmin.purgeQueue(queueName);
     }
 
     public static void clearDb(JpaRepository<?, ?> repository) {

--- a/notification-service/src/test/java/com/jobflow/notification_service/notification/AbstractNotificationServiceTest.java
+++ b/notification-service/src/test/java/com/jobflow/notification_service/notification/AbstractNotificationServiceTest.java
@@ -1,6 +1,7 @@
 package com.jobflow.notification_service.notification;
 
 import com.jobflow.notification_service.TestUtil;
+import com.jobflow.notification_service.exception.NotificationException;
 import com.jobflow.notification_service.exception.UserClientException;
 import com.jobflow.notification_service.notification.history.NotificationHistory;
 import com.jobflow.notification_service.notification.history.NotificationHistoryRepository;
@@ -14,6 +15,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -71,12 +73,14 @@ class AbstractNotificationServiceTest {
     }
 
     @Test
-    public void send_ifSomeExc_saveInDbCorrectlyInfo() {
+    public void send_ifSomeExc_throwExcAndSaveInDbCorrectlyInfo() {
         var userClientException = new UserClientException("User client exception");
         Long userId = notificationEvent.getUserId();
         when(userClient.getUserInfo(userId)).thenThrow(userClientException);
 
-        testNotificationService.send(notificationEvent);
+        var notificationException = assertThrows(NotificationException.class, () -> testNotificationService.send(notificationEvent));
+        assertEquals("Failed to sending notification event: " + userClientException.getMessage(),
+                notificationException.getMessage());
 
         verify(notificationHistoryService, times(1)).save(
                 notificationEvent,

--- a/notification-service/src/test/java/com/jobflow/notification_service/rabbitMQ/RabbitEmailConsumerIT.java
+++ b/notification-service/src/test/java/com/jobflow/notification_service/rabbitMQ/RabbitEmailConsumerIT.java
@@ -12,12 +12,15 @@ import com.jobflow.notification_service.user.UserInfo;
 import com.jobflow.notification_service.user.UserServiceProperties;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.amqp.core.AmqpAdmin;
 import org.springframework.amqp.core.AmqpTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.*;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
@@ -36,6 +39,9 @@ public class RabbitEmailConsumerIT extends BaseIT {
     private AmqpTemplate amqpTemplate;
 
     @Autowired
+    private AmqpAdmin amqpAdmin;
+
+    @Autowired
     private NotificationHistoryRepository historyRepository;
 
     @MockitoBean
@@ -51,6 +57,7 @@ public class RabbitEmailConsumerIT extends BaseIT {
     @BeforeEach
     public void setup() {
         TestUtil.clearDb(historyRepository);
+        TestUtil.clearRabbit(amqpAdmin, rabbitProperties.getEmailDlqName());
 
         notificationEvent = TestUtil.createNotificationEvent();
 
@@ -74,7 +81,10 @@ public class RabbitEmailConsumerIT extends BaseIT {
     public void consume_ifSuccess_saveInDbHistory() {
         consume_consumeNotificationEventAndSendEmailSuccessfully();
 
-        NotificationHistory savedNotification = historyRepository.findAll().get(0);
+        List<NotificationHistory> notifications = historyRepository.findAll();
+        assertEquals(1, notifications.size());
+
+        NotificationHistory savedNotification = notifications.get(0);
         assertNotNull(savedNotification);
         assertNotNull(savedNotification.getId());
         assertEquals(notificationEvent.getUserId(), savedNotification.getUserId());
@@ -109,7 +119,7 @@ public class RabbitEmailConsumerIT extends BaseIT {
     }
 
     @Test
-    public void consume_ifSomeExc_saveInDbHistory() {
+    public void consume_ifSomeExc_saveInDbHistoryAfterRetries() {
         var userClientException = new UserClientException("User client exception");
 
         when(restTemplate.exchange(
@@ -122,19 +132,51 @@ public class RabbitEmailConsumerIT extends BaseIT {
         sendMessageInQueue();
 
 
-        await().atMost(5, TimeUnit.SECONDS).until(() ->
-                historyRepository.findAll().size() == 1);
+        int maxAttempts = Integer.parseInt(rabbitProperties.getRetryableMaxAttempts());
+        int waitTimeMillis = Integer.parseInt(rabbitProperties.getRetryableDelay()) * maxAttempts;
+        await().atMost(waitTimeMillis + 3000, TimeUnit.MILLISECONDS).until(() ->
+                historyRepository.findAll().size() == maxAttempts);
 
-        NotificationHistory savedNotification = historyRepository.findAll().get(0);
-        assertNotNull(savedNotification);
-        assertNotNull(savedNotification.getId());
-        assertEquals(notificationEvent.getUserId(), savedNotification.getUserId());
-        assertEquals(NotificationType.EMAIL, savedNotification.getNotificationType());
-        assertEquals(notificationEvent.getSubject(), savedNotification.getSubject());
-        assertEquals(notificationEvent.getMessage(), savedNotification.getMessage());
-        assertFalse(savedNotification.getSuccess());
-        assertEquals(userClientException.getMessage(), savedNotification.getFailureReason());
-        assertNotNull(savedNotification.getCreatedAt());
+        List<NotificationHistory> notifications = historyRepository.findAll();
+
+        notifications.forEach(savedNotification -> {
+            assertNotNull(savedNotification);
+            assertNotNull(savedNotification.getId());
+            assertEquals(notificationEvent.getUserId(), savedNotification.getUserId());
+            assertEquals(NotificationType.EMAIL, savedNotification.getNotificationType());
+            assertEquals(notificationEvent.getSubject(), savedNotification.getSubject());
+            assertEquals(notificationEvent.getMessage(), savedNotification.getMessage());
+            assertFalse(savedNotification.getSuccess());
+            assertEquals(userClientException.getMessage(), savedNotification.getFailureReason());
+            assertNotNull(savedNotification.getCreatedAt());
+        });
+    }
+
+    @Test
+    public void consume_ifSomeExc_sendingEventInDlqCorrectly() {
+        var userClientException = new UserClientException("User client exception");
+
+        when(restTemplate.exchange(
+                eq(String.format("http://%s:%s/api/v1/users/info?userId=%s",
+                        userServiceProperties.getHost(), userServiceProperties.getPort(), notificationEvent.getUserId())),
+                eq(HttpMethod.GET),
+                any(HttpEntity.class),
+                eq(UserInfo.class)
+        )).thenThrow(userClientException);
+        sendMessageInQueue();
+
+        int maxAttempts = Integer.parseInt(rabbitProperties.getRetryableMaxAttempts());
+        int waitTimeMillis = Integer.parseInt(rabbitProperties.getRetryableDelay()) * maxAttempts;
+
+        NotificationEvent eventFromDlq = amqpTemplate.receiveAndConvert(
+                rabbitProperties.getEmailDlqName(), waitTimeMillis, new ParameterizedTypeReference<NotificationEvent>() {
+                });
+
+        assertNotNull(eventFromDlq);
+        assertEquals(eventFromDlq.getUserId(), notificationEvent.getUserId());
+        assertEquals(eventFromDlq.getNotificationType(), notificationEvent.getNotificationType());
+        assertEquals(eventFromDlq.getSubject(), notificationEvent.getSubject());
+        assertEquals(eventFromDlq.getMessage(), notificationEvent.getMessage());
     }
 
     private void mockFetchingUserInfo() {

--- a/notification-service/src/test/java/com/jobflow/notification_service/rabbitMQ/RabbitEmailConsumerTest.java
+++ b/notification-service/src/test/java/com/jobflow/notification_service/rabbitMQ/RabbitEmailConsumerTest.java
@@ -1,6 +1,7 @@
 package com.jobflow.notification_service.rabbitMQ;
 
 import com.jobflow.notification_service.TestUtil;
+import com.jobflow.notification_service.exception.NotificationException;
 import com.jobflow.notification_service.notification.AbstractNotificationService;
 import com.jobflow.notification_service.notification.NotificationEvent;
 import org.junit.jupiter.api.BeforeEach;
@@ -10,6 +11,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -33,5 +35,15 @@ class RabbitEmailConsumerTest {
         emailConsumer.consume(notificationEvent);
 
         verify(notificationService, times(1)).send(notificationEvent);
+    }
+
+    @Test
+    public void recover_throwExc() {
+        var notificationException = new NotificationException("Notification exception");
+
+        var result = assertThrows(
+                NotificationException.class, () -> emailConsumer.recover(notificationException, notificationEvent)
+        );
+        assertEquals(notificationException.getMessage(), result.getMessage());
     }
 }

--- a/notification-service/src/test/java/com/jobflow/notification_service/rabbitMQ/RabbitTelegramConsumerIT.java
+++ b/notification-service/src/test/java/com/jobflow/notification_service/rabbitMQ/RabbitTelegramConsumerIT.java
@@ -13,8 +13,10 @@ import com.jobflow.notification_service.user.UserServiceProperties;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.amqp.core.AmqpAdmin;
 import org.springframework.amqp.core.AmqpTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
@@ -23,6 +25,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.web.client.RestTemplate;
 import org.testcontainers.shaded.org.awaitility.Awaitility;
 
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -45,6 +48,9 @@ public class RabbitTelegramConsumerIT extends BaseIT {
     private AmqpTemplate amqpTemplate;
 
     @Autowired
+    private AmqpAdmin amqpAdmin;
+
+    @Autowired
     private NotificationHistoryRepository historyRepository;
 
     @MockitoBean
@@ -57,6 +63,7 @@ public class RabbitTelegramConsumerIT extends BaseIT {
     @BeforeEach
     public void setup() {
         TestUtil.clearDb(historyRepository);
+        TestUtil.clearRabbit(amqpAdmin, rabbitProperties.getTelegramDlqName());
 
         notificationEvent = TestUtil.createNotificationEvent();
 
@@ -89,7 +96,10 @@ public class RabbitTelegramConsumerIT extends BaseIT {
     public void consume_ifSuccess_saveInDbHistory() {
         consume_consumeNotificationEventAndSendToTelegramSuccessfully();
 
-        NotificationHistory savedNotification = historyRepository.findAll().get(0);
+        List<NotificationHistory> notifications = historyRepository.findAll();
+        assertEquals(1, notifications.size());
+
+        NotificationHistory savedNotification = notifications.get(0);
         assertNotNull(savedNotification);
         assertNotNull(savedNotification.getId());
         assertEquals(notificationEvent.getUserId(), savedNotification.getUserId());
@@ -124,7 +134,7 @@ public class RabbitTelegramConsumerIT extends BaseIT {
     }
 
     @Test
-    public void consume_ifSomeExc_saveInDbHistory() {
+    public void consume_ifSomeExc_saveInDbHistoryAfterRetries() {
         var userClientException = new UserClientException("User client exception");
 
         when(restTemplate.exchange(
@@ -136,20 +146,51 @@ public class RabbitTelegramConsumerIT extends BaseIT {
         )).thenThrow(userClientException);
         sendMessageInQueue();
 
+        int maxAttempts = Integer.parseInt(rabbitProperties.getRetryableMaxAttempts());
+        int waitTimeMillis = Integer.parseInt(rabbitProperties.getRetryableDelay()) * maxAttempts;
+        await().atMost(waitTimeMillis + 3000, TimeUnit.MILLISECONDS).until(() ->
+                historyRepository.findAll().size() == maxAttempts);
 
-        await().atMost(5, TimeUnit.SECONDS).until(() ->
-                historyRepository.findAll().size() == 1);
+        List<NotificationHistory> notifications = historyRepository.findAll();
 
-        NotificationHistory savedNotification = historyRepository.findAll().get(0);
-        assertNotNull(savedNotification);
-        assertNotNull(savedNotification.getId());
-        assertEquals(notificationEvent.getUserId(), savedNotification.getUserId());
-        assertEquals(NotificationType.TELEGRAM, savedNotification.getNotificationType());
-        assertEquals(notificationEvent.getSubject(), savedNotification.getSubject());
-        assertEquals(notificationEvent.getMessage(), savedNotification.getMessage());
-        assertFalse(savedNotification.getSuccess());
-        assertEquals(userClientException.getMessage(), savedNotification.getFailureReason());
-        assertNotNull(savedNotification.getCreatedAt());
+        notifications.forEach(savedNotification -> {
+            assertNotNull(savedNotification);
+            assertNotNull(savedNotification.getId());
+            assertEquals(notificationEvent.getUserId(), savedNotification.getUserId());
+            assertEquals(NotificationType.TELEGRAM, savedNotification.getNotificationType());
+            assertEquals(notificationEvent.getSubject(), savedNotification.getSubject());
+            assertEquals(notificationEvent.getMessage(), savedNotification.getMessage());
+            assertFalse(savedNotification.getSuccess());
+            assertEquals(userClientException.getMessage(), savedNotification.getFailureReason());
+            assertNotNull(savedNotification.getCreatedAt());
+        });
+    }
+
+    @Test
+    public void consume_ifSomeExc_sendingEventInDlqCorrectly() {
+        var userClientException = new UserClientException("User client exception");
+
+        when(restTemplate.exchange(
+                eq(String.format("http://%s:%s/api/v1/users/info?userId=%s",
+                        userServiceProperties.getHost(), userServiceProperties.getPort(), notificationEvent.getUserId())),
+                eq(HttpMethod.GET),
+                any(HttpEntity.class),
+                eq(UserInfo.class)
+        )).thenThrow(userClientException);
+        sendMessageInQueue();
+
+        int maxAttempts = Integer.parseInt(rabbitProperties.getRetryableMaxAttempts());
+        int waitTimeMillis = Integer.parseInt(rabbitProperties.getRetryableDelay()) * maxAttempts;
+
+        NotificationEvent eventFromDlq = amqpTemplate.receiveAndConvert(
+                rabbitProperties.getTelegramDlqName(), waitTimeMillis, new ParameterizedTypeReference<NotificationEvent>() {
+                });
+
+        assertNotNull(eventFromDlq);
+        assertEquals(eventFromDlq.getUserId(), notificationEvent.getUserId());
+        assertEquals(eventFromDlq.getNotificationType(), notificationEvent.getNotificationType());
+        assertEquals(eventFromDlq.getSubject(), notificationEvent.getSubject());
+        assertEquals(eventFromDlq.getMessage(), notificationEvent.getMessage());
     }
 
     private void sendMessageInQueue() {

--- a/notification-service/src/test/java/com/jobflow/notification_service/rabbitMQ/RabbitTelegramConsumerTest.java
+++ b/notification-service/src/test/java/com/jobflow/notification_service/rabbitMQ/RabbitTelegramConsumerTest.java
@@ -1,6 +1,7 @@
 package com.jobflow.notification_service.rabbitMQ;
 
 import com.jobflow.notification_service.TestUtil;
+import com.jobflow.notification_service.exception.NotificationException;
 import com.jobflow.notification_service.notification.AbstractNotificationService;
 import com.jobflow.notification_service.notification.NotificationEvent;
 import org.junit.jupiter.api.BeforeEach;
@@ -10,6 +11,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -33,6 +36,16 @@ class RabbitTelegramConsumerTest {
         telegramConsumer.consume(notificationEvent);
 
         verify(notificationService, times(1)).send(notificationEvent);
+    }
+
+    @Test
+    public void recover_throwExc() {
+        var notificationException = new NotificationException("Notification exception");
+
+        var result = assertThrows(
+                NotificationException.class, () -> telegramConsumer.recover(notificationException, notificationEvent)
+        );
+        assertEquals(notificationException.getMessage(), result.getMessage());
     }
 
 }

--- a/notification-service/src/test/resources/application.properties
+++ b/notification-service/src/test/resources/application.properties
@@ -1,8 +1,18 @@
+spring.rabbitmq.exchange-name=notification.exchange
+spring.rabbitmq.dle-name=notification.dle
+
 spring.rabbitmq.email-queue-name=notification.email.queue
 spring.rabbitmq.telegram-queue-name=notification.telegram.queue
-spring.rabbitmq.exchange-name=notification.exchange
+spring.rabbitmq.email-dlq-name=notification.email.dlq
+spring.rabbitmq.telegram-dlq-name=notification.telegram.dlq
+
 spring.rabbitmq.email-queue-routing-key=notification.email.queue
 spring.rabbitmq.telegram-queue-routing-key=notification.telegram.queue
+spring.rabbitmq.email-dlq-routing-key=notification.email.dlq
+spring.rabbitmq.telegram-dlq-routing-key=notification.telegram.dlq
+
+spring.rabbitmq.retryable-max-attempts=3
+spring.rabbitmq.retryable-delay=1000
 
 spring.jpa.hibernate.ddl-auto=update
 

--- a/user-service/Dockerfile
+++ b/user-service/Dockerfile
@@ -1,15 +1,15 @@
-#FROM maven:latest AS builder
-#WORKDIR /app
-#COPY . .
-#RUN mvn clean package -DskipTests
-#
-#FROM openjdk:latest
-#WORKDIR /app
-#COPY --from=builder /app/target/user-service-0.0.1-SNAPSHOT.jar app.jar
-#ENTRYPOINT ["java", "-jar", "/app/app.jar"]
+FROM maven:latest AS builder
+WORKDIR /app
+COPY . .
+RUN mvn clean package -DskipTests
 
 FROM openjdk:latest
 WORKDIR /app
-COPY /target/user-service-0.0.1-SNAPSHOT.jar /app/app.jar
-ENTRYPOINT ["java", "-jar", "app.jar"]
+COPY --from=builder /app/target/user-service-0.0.1-SNAPSHOT.jar app.jar
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]
+
+#FROM openjdk:latest
+#WORKDIR /app
+#COPY /target/user-service-0.0.1-SNAPSHOT.jar /app/app.jar
+#ENTRYPOINT ["java", "-jar", "app.jar"]
 


### PR DESCRIPTION
- Added email and telegram dead letter queues and direct dead letter exchange to RabbitMQ
- Set up telegram and email queues to send messages to DLE with routing key in case of a fail
- Configured the retryable logic in consumers so that the notification is resent 3 times after a failure
- Set up a recover method that logs the unsuccessful sending of a notification and throws a custom exception (the message is then sent to DLQ)
- Covered with unit and integration tests
- Refactored existing integration tests with retryable verification